### PR TITLE
 [Draft solution] Add S3 Sink Connector V2

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorV2.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorV2.java
@@ -1,0 +1,30 @@
+package io.confluent.connect.s3;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.Task;
+
+public class S3SinkConnectorV2 extends S3SinkConnector {
+    @Override
+    public Class<? extends Task> taskClass() {
+        return S3SinkTaskV2.class;
+    }
+    public S3SinkConnectorV2() {
+        // no-arg constructor required by Connect framework.
+    }
+
+    @Override
+    public ConfigDef config() {
+        ConfigDef configDef = S3SinkConnectorConfig.getConfig();
+        configDef.define("transform.threads.max",
+                ConfigDef.Type.INT,
+                1,
+                ConfigDef.Importance.HIGH,
+                "Max number of threads to use for converting batch of records in parallel.",
+                "parallel_processing",
+                1,
+                ConfigDef.Width.LONG,
+                "Max number of threads to use for converting batch of records in parallel."
+        );
+        return configDef;
+    }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorV2.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorV2.java
@@ -3,6 +3,7 @@ package io.confluent.connect.s3;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 
+
 public class S3SinkConnectorV2 extends S3SinkConnector {
     @Override
     public Class<? extends Task> taskClass() {
@@ -10,6 +11,7 @@ public class S3SinkConnectorV2 extends S3SinkConnector {
     }
     public S3SinkConnectorV2() {
         // no-arg constructor required by Connect framework.
+
     }
 
     @Override
@@ -27,4 +29,6 @@ public class S3SinkConnectorV2 extends S3SinkConnector {
         );
         return configDef;
     }
+
+
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorV2.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorV2.java
@@ -1,6 +1,5 @@
 package io.confluent.connect.s3;
 
-import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
 
 
@@ -13,22 +12,5 @@ public class S3SinkConnectorV2 extends S3SinkConnector {
         // no-arg constructor required by Connect framework.
 
     }
-
-    @Override
-    public ConfigDef config() {
-        ConfigDef configDef = S3SinkConnectorConfig.getConfig();
-        configDef.define("transform.threads.max",
-                ConfigDef.Type.INT,
-                1,
-                ConfigDef.Importance.HIGH,
-                "Max number of threads to use for converting batch of records in parallel.",
-                "parallel_processing",
-                1,
-                ConfigDef.Width.LONG,
-                "Max number of threads to use for converting batch of records in parallel."
-        );
-        return configDef;
-    }
-
 
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTaskV2.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTaskV2.java
@@ -1,0 +1,86 @@
+package io.confluent.connect.s3;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.CoerceToSegmentPayload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.hotstar.kafka.connect.transforms.ProtoToPayloadTransform;
+
+public class S3SinkTaskV2 extends S3SinkTask {
+    private ExecutorService executorService;
+    public static final long THREAD_KEEP_ALIVE_TIME_SECONDS = 60L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3SinkTaskV2.class);
+
+    private static final ProtoToPayloadTransform.Value<SinkRecord> protoToPayloadTransform = new ProtoToPayloadTransform.Value<>();
+    private static final CoerceToSegmentPayload<SinkRecord> coerceToSegmentPayloadTransform = new CoerceToSegmentPayload.Value<>();
+
+    static {
+        // This is needed to initialise the statsD client with default values.
+        protoToPayloadTransform.configure(new HashMap<>());
+
+    }
+
+
+    @Override
+    public void start(Map<String, String> props) {
+        super.start(props);
+        int transformThreadPoolMaxSize = Integer.parseInt(props.get("transform.threads.max"));
+        this.executorService = new ThreadPoolExecutor(1, transformThreadPoolMaxSize,
+                THREAD_KEEP_ALIVE_TIME_SECONDS,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
+                new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+    }
+
+    @Override
+    public void put(Collection<SinkRecord> records) throws ConnectException {
+        transformInParallel(records);
+        super.put(records);
+    }
+
+    private Collection<SinkRecord> transformInParallel(Collection<SinkRecord> sinkRecords) {
+        int batchSize = sinkRecords.size();
+        SinkRecord[] kafkaRecordArray = sinkRecords.toArray(new SinkRecord[0]);
+        List<Future<SinkRecord>> futureList = new ArrayList<>(batchSize);
+//        LOGGER.debug("In transformInParallel Method.");
+        for (int i = 0; i < batchSize; i++) {
+            int recordNumber = i;
+            futureList.add(executorService.submit((Callable) () -> transformProtoToEventPayload(kafkaRecordArray[recordNumber])));
+        }
+        List<SinkRecord> transformedRecords = new ArrayList<>(batchSize);
+        futureList.stream().forEach(future -> {
+            try {
+                SinkRecord transformedRecord = future.get();
+                transformedRecords.add(transformedRecord);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return transformedRecords;
+    }
+
+    private SinkRecord transformProtoToEventPayload(SinkRecord sinkRecord){
+//        LOGGER.warn("Staring protoToPayloadTransform  on {}",sinkRecord);
+        SinkRecord intermediateRecord = protoToPayloadTransform.apply(sinkRecord);
+//        LOGGER.warn("Staring coerceToSegmentPayload  on {}",intermediateRecord);
+        return coerceToSegmentPayloadTransform.apply(intermediateRecord);
+    }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTaskV2.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTaskV2.java
@@ -24,6 +24,7 @@ import static com.hotstar.kafka.connect.transforms.util.StatsDConstants.STATSD_P
 
 public class S3SinkTaskV2 extends S3SinkTask {
     public static final Logger log = LoggerFactory.getLogger(S3SinkTaskV2.class);
+    public static final String KAFKA_PARTITION_TAG = "partition:%s";
     private static final ProtoToPayloadTransform.Value<SinkRecord> protoToPayloadTransform = new ProtoToPayloadTransform.Value<>();
     private static final CoerceToSegmentPayload<SinkRecord> coerceToSegmentPayloadTransform = new CoerceToSegmentPayload.Value<>();
 
@@ -57,10 +58,11 @@ public class S3SinkTaskV2 extends S3SinkTask {
             // log.warn("Skipping the record as it doesn't have the required fields", ex);
         }
         String eventNameTag = String.format(EVENT_NAME_TAG, firstRecord.topic());
+        String partitionTag = String.format(KAFKA_PARTITION_TAG, firstRecord.kafkaPartition().toString());
         long putStartTime = System.nanoTime();
         super.put(transformedRecords);
         statsDClient.timing("put.time", System.nanoTime()-putStartTime, eventNameTag);
-        statsDClient.gauge("batch.ts_received_ms", eventReceivedTimeMs, eventNameTag);
+        statsDClient.gauge("batch.ts_received_ms", eventReceivedTimeMs, eventNameTag, partitionTag);
     }
 
     private Collection<SinkRecord> transformInParallel(Collection<SinkRecord> sinkRecords) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTaskV2.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTaskV2.java
@@ -4,21 +4,13 @@ import com.hotstar.utils.StatsDClient;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.transforms.CoerceToSegmentPayload;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import com.hotstar.kafka.connect.transforms.ProtoToPayloadTransform;
 
@@ -27,10 +19,6 @@ import static com.hotstar.kafka.connect.transforms.util.StatsDConstants.STATSD_H
 import static com.hotstar.kafka.connect.transforms.util.StatsDConstants.STATSD_PORT_DEFAULT;
 
 public class S3SinkTaskV2 extends S3SinkTask {
-    private ExecutorService executorService;
-    public static final long THREAD_KEEP_ALIVE_TIME_SECONDS = 60L;
-    private static final Logger LOGGER = LoggerFactory.getLogger(S3SinkTaskV2.class);
-
     private static final ProtoToPayloadTransform.Value<SinkRecord> protoToPayloadTransform = new ProtoToPayloadTransform.Value<>();
     private static final CoerceToSegmentPayload<SinkRecord> coerceToSegmentPayloadTransform = new CoerceToSegmentPayload.Value<>();
 
@@ -41,62 +29,35 @@ public class S3SinkTaskV2 extends S3SinkTask {
         protoToPayloadTransform.configure(new HashMap<>());
         statsDClient = new StatsDClient.Builder()
                 .hostAndPort(STATSD_HOST_DEFAULT, STATSD_PORT_DEFAULT)
-                .namespace("s3connector.v2")
+                .namespace("connector.custom.metrics.s3.v2")
                 .create();
-    }
 
-
-    @Override
-    public void start(Map<String, String> props) {
-        super.start(props);
-        int transformThreadPoolMaxSize = Integer.parseInt(props.get("transform.threads.max"));
-        this.executorService = new ThreadPoolExecutor(1, transformThreadPoolMaxSize,
-                THREAD_KEEP_ALIVE_TIME_SECONDS,
-                TimeUnit.SECONDS,
-                new SynchronousQueue<>(),
-                new ThreadPoolExecutor.CallerRunsPolicy()
-        );
     }
 
     @Override
     public void put(Collection<SinkRecord> records) throws ConnectException {
         ArrayList<SinkRecord> transformedRecords = (ArrayList)transformInParallel(records);
-        if(transformedRecords.size() == 0 ){
+        if(transformedRecords.isEmpty()){
             return;
         }
         String eventNameTag = String.format(EVENT_NAME_TAG, transformedRecords.get(0).topic());
         long putStartTime = System.nanoTime();
         super.put(transformedRecords);
-        statsDClient.timing("s3.put.time", System.nanoTime()-putStartTime, eventNameTag);
+        statsDClient.timing("put.time", System.nanoTime()-putStartTime, eventNameTag);
     }
 
     private Collection<SinkRecord> transformInParallel(Collection<SinkRecord> sinkRecords) {
         int batchSize = sinkRecords.size();
-        if (batchSize == 0 ){
+        if (sinkRecords.isEmpty()){
             return sinkRecords;
         }
-        long startTransformTime = System.nanoTime();
-        SinkRecord[] kafkaRecordArray = sinkRecords.toArray(new SinkRecord[0]);
-        String eventNameTag = String.format(EVENT_NAME_TAG, kafkaRecordArray[0].topic());
+        Iterator<SinkRecord> iterator = sinkRecords.iterator();
+        String eventNameTag = String.format(EVENT_NAME_TAG, iterator.next().topic());
         statsDClient.gauge("batch.size",batchSize,eventNameTag);
-        List<Future<SinkRecord>> futureList = new ArrayList<>(batchSize);
-        for (int i = 0; i < batchSize; i++) {
-            int recordNumber = i;
-            futureList.add(executorService.submit((Callable) () -> transformProtoToEventPayload(kafkaRecordArray[recordNumber])));
-        }
-        List<SinkRecord> transformedRecords = new ArrayList<>(batchSize);
-        futureList.stream().forEach(future -> {
-            try {
-                SinkRecord transformedRecord = future.get();
-                transformedRecords.add(transformedRecord);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            } catch (ExecutionException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        long startTransformTime = System.nanoTime();
+        List<SinkRecord> collect = sinkRecords.parallelStream().map(x -> transformProtoToEventPayload(x)).collect(Collectors.toList());
         statsDClient.timing("transform.time",System.nanoTime()-startTransformTime, eventNameTag);
-        return transformedRecords;
+        return collect;
     }
 
     private SinkRecord transformProtoToEventPayload(SinkRecord record){

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>com.hotstar</groupId>
             <artifactId>kafka-connect-plugins_2.11</artifactId>
-            <version>0.1.0-SNAPSHOT</version>
+            <version>0.1.0</version>
 <!--            <scope>provided</scope>-->
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     </modules>
 
     <properties>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <licenses.version>5.5.3</licenses.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <hadoop.version>2.7.7</hadoop.version>
@@ -67,9 +67,25 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>confluent</id>
-            <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+        <repository>
+            <id>data-platform</id>
+            <name>Data Platform</name>
+            <url>https://nexus.hotstar.com/repository/data-platform/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
 
@@ -105,6 +121,12 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-partitioner</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hotstar</groupId>
+            <artifactId>kafka-connect-plugins_2.11</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+<!--            <scope>provided</scope>-->
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION

S3SinkConnectorV2 extends the original class S3SinkConnector.
Similarly S3SinkTaskV2 extends the original class S3SinkTask.

New connector was created so that we can still use the plain S3SinkConnector.
New SinkClass transforms the records in parallel.

The Connectors needs the kafka-connect-plugins and the minerva jar in the directory.(This was added manually for now)

Confluent repo's url was changed and I am using https url instead of http one since I was getting dependency resolution errors in that case.

To build this package command used was :
 mvn clean install -Dcheckstyle.skip

**Sample connector config**:

- Note that most configs are same as S3 Sink Connector
-  `transform.threads.max` is a new config

 
```json
{
  "connector.class": "io.confluent.connect.s3.S3SinkConnectorV2",
  "consumer.override.partition.assignment.strategy": "org.apache.kafka.clients.consumer.StickyAssignor",
  "errors.tolerance": "all",
  "flush.size": "1000000",
  "format.class": "io.confluent.connect.s3.format.json.JsonFormat",
  "key.converter": "org.apache.kafka.connect.storage.StringConverter",
  "key.converter.schemas.enable": "false",
  "locale": "en",
  "name": "in-x-s3-sink-app_opened-hercules",
  "partition.duration.ms": "600000",
  "partitioner.class": "com.hotstar.connect.storage.partitioner.KnolPartitioner",
  "path.format": "'cd'=YYYY-MM-dd/'hr'=HH",
  "rotate.schedule.interval.ms": "300000",
  "s3.bucket.name": "hotstar-dp-datalake-raw-ap-southeast-1-pp",
  "s3.compression.type": "gzip",
  "s3.part.size": "5242880",
  "s3.region": "ap-southeast-1",
  "schema.compatibility": "NONE",
  "schema.generator.class": "io.confluent.connect.storage.hive.schema.DefaultSchemaGenerator",
  "storage.class": "io.confluent.connect.s3.storage.S3Storage",
  "tasks.max": "1",
  "timestamp.extractor": "Wallclock",
  "timezone": "GMT",
  "topics.dir": "x-raw-data-gd",
  "topics.regex": "ca.knol.analytics.app_opened.raw",
  "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
  "value.converter.schemas.enable": "false",
  "rotate.interval.ms": "-1",
  "transform.threads.max": "50",
  "consumer.override.max.poll.records": "50000",
  "consumer.override.receive.buffer.bytes": "10485760",
  "consumer.override.max.partition.fetch.bytes": "104857600"
}
```
Sample JSON Output from S3 File : 
```
{"anonymousId":"eec452e8-2743-4878-9870-a170a649efcc","channel":null,"event":"App Opened","messageId":"9f47adea-dabc-49be-82a5-5368420deca7","userId":"a1f9d38e-ebca-418b-9401-3968321c3489","timestamp":"2023-05-22T08:38:49.265Z","properties":{"step_status":"","app_language":"eng","account_type":"email","binder_version":"","referrer_page_binder_version":"","partner_name":"d2c","referrer_page_id":"","referrer_page_template":"","is_hdr_enabled":false,"processor_family_name":"ranchu","subscription_status":"active","id":"","app_id":"in.startv.hotstar","total_disk_space_gb":5.81207275390625,"is_bluetooth_on":false,"max_ram_floored_value":0,"is_cellular_on":false,"is_dark_mode_enabled":false,"appsuite_type":"be8eefd6-dd3a-33af-829e-37c075ebf792","data_source":"x","plan_frequency":1,"referrer_binder":"","referrer_page_title":"","player_status":"unspecified","subs_pack_name":"","is_battery_charging":true,"appsuite_id":"9318995b-eae1-3b6b-ab2f-01aeeef44ff5","common_size_bytes":0,"ts_session_start_ms":1684744670993,"battery_is_charging":true,"template":"","referrer_binder_version":"","batch_id":"cad37f35-6ba3-484d-93ca-418bac886332","ts_occurred_ms":1684744729265,"page_type":"unspecified","is_email_verified":false,"batch_num_events":10,"ram_capacity_mb":3929,"group_ids":["02754f","05c989","10c1f6","1cm7xk","23ecb4","2v7nim","4b686f","4c91f8","4ibvey","5505c1","66206a","6ne0wv","6t1yyu","732aba","79b1a0","7df79b","7g74e9","7km1gm","7o445f","8190eb","820c96","942uy0","9ef54a","a919bb","b00f7f","b1bw01","bea933","bq17j6","c13qpj","cb7e5e","cf76a1","d19gtf","d3geka","df1c02","e49f28","e75358","ece4e8","elqhy9","f0t1za","f3e7e6","f89126","fjugg2","fx8l3h","hgwtbz","hxcan3","ivdww5","jqdwbz","k4t5d5","kcnice","korodq","lMKepQ","o5lf39","oecnx6","pdur1c","pvsk36","qkivo4","sg4k50","thkpd7","us1rvb","w3wggp","whodyb","x2oysu","xdr1gx","xseso3","xuyrkj","z2poan","zeyr7k","zltak2","zxmmr6"],"is_wifi_on":true,"currency":"","network_speed_kbps":0,"available_disk_space_gb":5.428306579589844,"page_template":"","is_low_power_mode_enabled":false,"message_id":"9f47adea-dabc-49be-82a5-5368420deca7","ssai_tag":"","referrer_page_type":"unspecified","ts_sent_ms":1684744730974,"lpvs":["hin","tam","tel","eng","ben","mar","mal","kan"],"width_px":1080,"ts_computed_at_ms":1684744692929,"home_country":"CA","asn_number":4755,"network_type":"wifi","active_processor_count":0,"asn":0,"plan_id":"DHSPremium.IN.Year.1499","page_url":"","is_phone_verified":false,"referrer_id":"","ts_latest_subscription_end_date_ms":1715959043000,"page_title":"","utm_medium":"","is_spoofing_enabled":false,"available_ram_mb":2246,"page_binder_version":"","binder":"","is_device_rooted":false,"utm_campaign":"","primary_language":"hin","cellular_mcc_mnc":"310260","is_memory_warning_raised":false,"current_country_code":"","screen_resolution_type":"xxhdpi","event_size_bytes":0,"referrer_template":"","page_binder":"","utm_source":"","brightness_level_percent":40,"batch_size_bytes":33006,"total_processor_count":2,"page_id":"","battery_strength_percent":100,"plan_duration_type":"year","max_fps":60,"utm_content":"","user_status":"","wifi_ssid":"","amount":"","referrer_space_id":"","height_px":1776,"is_user_logged_in":true,"ts_received_ms":1689773986544,"ip_address":"14.143.43.134","player_type":"unspecified","utm_term":"","carrier":"Android","permission_os":false,"ts_latest_subscription_start_date_ms":1684423044000,"days_to_expiry":361,"referrer_page_url":"","maturity_rating":"","step":"start","plan_family":"HotstarPremium","referrer_page_binder":"","space_id":""},"traits":{},"context":{"active":null,"app":{"name":"Hotstar","version":"23.05.22.3","build":8561},"campaign":null,"device":{"id":"78b06f7223c6e030","advertisingId":"","manufacturer":"unknown","model":"Android SDK built for x86","name":"generic_x86","type":null,"version":null},"groupId":null,"network":null,"os":{"name":null,"version":"30"},"traits":{"country":"ca","h_id":"2569b17bfdb84414857c1449d63e4e9b","device_id":"78b06f7223c6e030","af_conversion_type":"unspecified","city":"MUMBAI","session_id":"62ca92b9-bd08-42e0-b6f8-fc68880af3ea","type":"adult","long":72.83,"platform":"android","browser_name":"","notification_permission":"granted","name":"uphaar dasd","appsflyer_id":"1684744005429-9111439360175798052","is_ad_tracking_enabled":false,"phone_number":0,"browser_version":"","state":"MH","push_token":"cF7VGxwtS9m07XTQ3Tpip_:APA91bGjElBtPzNmB2-XSXXI_BkQSA8JzvbEgxP9Ml3QVIpXBf2Z2v2SEDMZiSJcO1CsoJHOtSHJjC4Ed-JprVSwKdqglKy8alKpHPWNTBHzW7rEZ0YoCIprHPr5_yyNNZUZfc_wEcVd","email":"","lat":18.98,"p_id":"660b76bd99e14630977e710d787d2cb8"},"library":{"name":"com.hotstar.bifrostlib","version":"1.2.19"},"locale":null,"page":null,"referrer":null,"screen":null,"timezone":null,"userAgent":null},"ts_occurred_ms":1684744729265,"message_id":"9f47adea-dabc-49be-82a5-5368420deca7","receivedAt":"2023-07-19T13:39:46Z"}
```

No data loss is happening : 
3 files were written for partition 0 : 

- [ca.knol.analytics.app_opened.raw+0+0000000000.json.gz](https://s3.console.aws.amazon.com/s3/object/hotstar-dp-datalake-raw-ap-southeast-1-pp?region=ap-southeast-1&prefix=x-raw-data-gd/APP_OPENED_EVENTS/cd%3D2023-08-03/hr%3D21/ca.knol.analytics.app_opened.raw%2B0%2B0000000000.json.gz)
- [ca.knol.analytics.app_opened.raw+0+0000000001.json.gz](https://s3.console.aws.amazon.com/s3/object/hotstar-dp-datalake-raw-ap-southeast-1-pp?region=ap-southeast-1&prefix=x-raw-data-gd/APP_OPENED_EVENTS/cd%3D2023-08-03/hr%3D21/ca.knol.analytics.app_opened.raw%2B0%2B0000000001.json.gz)
- [ca.knol.analytics.app_opened.raw+0+0000891427.json.gz](https://s3.console.aws.amazon.com/s3/object/hotstar-dp-datalake-raw-ap-southeast-1-pp?region=ap-southeast-1&prefix=x-raw-data-gd/APP_OPENED_EVENTS/cd%3D2023-08-03/hr%3D21/ca.knol.analytics.app_opened.raw%2B0%2B0000891427.json.gz)


Based on this, the 2nd file should have  891426(start offset of next file -1 ) - 1(start offset of current file) + 1 = 891426 records and this was verified.

```
ubuntu@controlCenter1:~$ wc -l ~/shivanjal/in-dw-gd-experiments/jsons/ca.knol.analytics.app_opened.raw+0+0000000001.json
891426 /home/ubuntu/shivanjal/in-dw-gd-experiments/jsons/ca.knol.analytics.app_opened.raw+0+0000000001.json 
```